### PR TITLE
Remove: 'body-parser' module and '.ejs' extension in res.render

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,4 @@
 const express = require("express");
-var bodyParser = require("body-parser");
 
 const app = express();
 
@@ -11,29 +10,27 @@ app.use(express.static(__dirname + "/public"));
 
 app.set("view engine", "ejs");
 
-var bodyParser = require("body-parser");
-app.use(bodyParser.urlencoded({ extended: true }));
-app.use(bodyParser.json());
+app.use(express.json());
 app.use(
-  bodyParser.urlencoded({
+  express.urlencoded({
     extended: true,
   })
 );
 
 app.get("/", (req, res) => {
-    res.render("./login.ejs");
+    res.render("./login");
 });
 
 app.get("/index", (req, res) => {
-    res.render("./index.ejs");
+    res.render("./index");
 });
 
 app.get("/charthome", (req, res) => {
-    res.render("./charthome.ejs");
+    res.render("./charthome");
 });
 
 app.get("/academic", (req, res) => {
-    res.render("./academic.ejs");
+    res.render("./academic");
 });
 
 app.get("/nonacad", (req, res) => {
@@ -45,11 +42,11 @@ app.get("/comparative", (req, res) => {
 });
 
 app.get("/team", (req, res) => {
-    res.render("./teamkshitij.ejs");
+    res.render("./teamkshitij");
 });
 
 app.get("*", (req, res) => {
-    res.render("./notfound.ejs");
+    res.render("./notfound");
 });
   
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "body-parser": "^1.19.0",
     "ejs": "^3.1.6",
     "express": "^4.17.1",
     "method-override": "^3.0.0",

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -617,12 +617,10 @@
 						</h5>
 						<button
 							type="button"
-							class="close"
-							data-dismiss="modal"
+							class="btn-close"
+							data-bs-dismiss="modal"
 							aria-label="Close"
-						>
-							<span aria-hidden="true">&times;</span>
-						</button>
+						></button>
 					</div>
 					<div class="modal-body">
 						<iframe


### PR DESCRIPTION
1. Set express instead of body-parser(deprecated)
2. Remove '.ejs' in all res.render
3. Fix the close button not working issue in 'modal 3'